### PR TITLE
Set TEXDIR explicitly for removing dependence on kpsewhich

### DIFF
--- a/lib/Chart/Gnuplot/CustomBuilder.pm6
+++ b/lib/Chart/Gnuplot/CustomBuilder.pm6
@@ -41,7 +41,7 @@ class Chart::Gnuplot::CustomBuilder:ver<0.0.19> is Distribution::Builder::MakeFr
         my $extractor = Zef::Extract.new(:backends(@extract-backends));
         my $extract-dir = $extractor.extract(Candidate.new(:uri($archive-file)), $*CWD);
         chdir("gnuplot-5.2.6");
-        shell("./configure --prefix=$prefix");
+        shell("./configure --prefix=$prefix --with-latex --with-texdir={$prefix}/share/texmf/tex/latex/gnuplot");
         shell("make");
         shell("make install");
         chdir($goback);


### PR DESCRIPTION
Fix #42 

### Context

See: https://github.com/gnuplot/gnuplot/blob/branch-5-4-stable/configure.ac#L121-L162
As you can see, the steps are as follows:
1) `./configure` sets `with-latex=yes` as a default value
2) Check if `with-latex=yes` is really true
3) If neither TEXDIR nor path to the `kpsewhich` (`kpsewhich` is the command which returns a TEXDIR) are given, this install process fails.

If you pass the step 3 without setting TEXTDIR manually, permission issue may happens because `kpsewhich` sometimes returns a dir that is owned by root.

### Changes proposed in this PR

+ `CustomBuilder.pm6` explicitly sets TEXDIR by `--with-latex` and `--with-texdir=...` arguments